### PR TITLE
Update style guide

### DIFF
--- a/elixir_style_guide.md
+++ b/elixir_style_guide.md
@@ -4,15 +4,15 @@
 
     ```elixir
     def foo, do: do_foo + something
-    
+
     defp do_foo, do: 1
-    
+
     def bar, do: do_bar + something
-    
+
     defp do_bar, do: 2
-    
+
     defp something, do: 100
-    
+
     ```
 
 - Do not put blank lines between different definitions for the same function (where name and arity match).
@@ -20,7 +20,7 @@
     ```elixir
     def foo(0), do: 0
     def foo(x), do: x + 1
-    
+
     def foo(x, y), do: x * y
     ```
 
@@ -30,7 +30,7 @@
 
     ```elixir
     alias MyApp.{Alpha, Bravo}
-    
+
     def foo, do: Alpha.foo + Bravo.foo
     ```
 
@@ -39,12 +39,12 @@
     ```elixir
     use Application
     doctest MyApp
-    
+
     alias MyApp.{Alpha, Bravo}
     import Something, only: [foo: 1]
     require SomethingElse
     ```
-    
+
 - Avoiding importing whole modules; import only the functions you need using the `only:` option. You can make an exception for `Ecto.Changeset`.
 
     ```elixir
@@ -63,7 +63,7 @@
     ```elixir
     # bad
     MapSet.new()
-    
+
     # good
     MapSet.new
     ```
@@ -72,124 +72,74 @@
 
     ```elixir
     # bad
-    [a: "alpha", 
-     b: "bravo", 
-     c: "charlie", 
-     d: "delta", 
-     e: "echo", 
-     f: "foxtrot", 
+    [a: "alpha",
+     b: "bravo",
+     c: "charlie",
+     d: "delta",
+     e: "echo",
+     f: "foxtrot",
      g: "golf"]
-    
+
     # good
     [
-      a: "alpha", 
-      b: "bravo", 
-      c: "charlie", 
-      d: "delta", 
-      e: "echo", 
-      f: "foxtrot", 
+      a: "alpha",
+      b: "bravo",
+      c: "charlie",
+      d: "delta",
+      e: "echo",
+      f: "foxtrot",
       g: "golf",
     ]
     ```
-    
+
     ```elixir
     # bad
-    %{a: "alpha", 
-      b: "bravo", 
-      c: "charlie", 
-      d: "delta", 
-      e: "echo", 
-      f: "foxtrot", 
+    %{a: "alpha",
+      b: "bravo",
+      c: "charlie",
+      d: "delta",
+      e: "echo",
+      f: "foxtrot",
       g: "golf"}
-    
+
     # good
     %{
-      a: "alpha", 
-      b: "bravo", 
-      c: "charlie", 
-      d: "delta", 
-      e: "echo", 
-      f: "foxtrot", 
+      a: "alpha",
+      b: "bravo",
+      c: "charlie",
+      d: "delta",
+      e: "echo",
+      f: "foxtrot",
       g: "golf",
     }
 
     ```
-    
+
     ```elixir
     # bad
     # bad
-    ["alpha", 
-     "bravo", 
-     "charlie", 
-     "delta", 
-     "echo", 
-     "foxtrot", 
+    ["alpha",
+     "bravo",
+     "charlie",
+     "delta",
+     "echo",
+     "foxtrot",
      "golf",
      "hotel",
      "india"]
-    
+
     # good
     [
-      "alpha", 
-      "bravo", 
-      "charlie", 
-      "delta", 
-      "echo", 
-      "foxtrot", 
+      "alpha",
+      "bravo",
+      "charlie",
+      "delta",
+      "echo",
+      "foxtrot",
       "golf",
       "hotel",
       "india",
     ]
-    ```
-
-- When a keyword list or map spans multiple lines, align the values.
-
-    ```elixir
-    # bad
-    [
-      foo: 1_000,
-      bar_bar: %{
-        apple: 1,
-        banana: 2,
-        cherry: 3,
-      },
-      baz_baz_baz: 3_000,
-    ]
-    
-    # good
-    [
-      foo:         1_000,
-      bar_bar:     %{
-        apple:  1,
-        banana: 2,
-        cherry: 3,
-      },
-      baz_baz_baz: 3_000,
-    ]
-    ```
-    
-    ```elixir
-    # bad
-    %{
-      foo: 1_000,
-      bar_bar: %{
-        apple: 1,
-        banana: 2,
-        cherry: 3,
-      },
-      baz_baz_baz: 3_000,
-    }
-    
-    # good
-    %{
-      foo:         1_000,
-      bar_bar:     %{
-        apple:  1,
-        banana: 2,
-        cherry: 3,
-      },
-      baz_baz_baz: 3_000,
-    }
     ```
 
 - If a call ends in a keyword list, omit the square brackets.
@@ -197,7 +147,7 @@
     ```elixir
     # bad
     foo(42, [with: 1, and: 2])
-    
+
     # good
     foo(42, with: 1, and: 2)
     ```
@@ -209,11 +159,11 @@
     def foo do
       42
     end
-    
+
     # good
     def foo, do: 42
     ```
-    
+
     ```elixir
     # bad
     if year > 2016 do
@@ -221,7 +171,7 @@
     else
       3
     end
-    
+
     # good
     if year > 2016, do: 42, else: 3
     ```
@@ -231,54 +181,54 @@
     ```elixir
     # bad
     foo = fn
-      nil -> 
+      nil ->
         :error
       _ ->
         :ok
-    end 
-    
+    end
+
     # good
     foo = fn
       nil -> :error
       _ -> :ok
-    end 
+    end
     ```
-    
+
     ```elixir
     # bad
     case foo.(x) do
-      :ok -> 
+      :ok ->
         42
       :error ->
         3
     end
-    
+
     # good
     case foo.(x) do
       :ok -> 42
       :error -> 3
     end
     ```
-    
+
     ```elixir
     # bad
     bar = fn
-      nil -> 
+      nil ->
         IO.puts("ERROR")
         :error
       _ -> :ok
-    end 
-    
+    end
+
     # good
     bar = fn
-      nil -> 
+      nil ->
         IO.puts("ERROR")
         :error
-      _ -> 
+      _ ->
         :ok
-    end 
+    end
     ```
-    
+
     ```elixir
     # bad
     case bar.(x) do
@@ -288,10 +238,10 @@
         |> inspect()
         |> raise()
     end
-    
+
     # good
     case bar.(x) do
-      :ok -> 
+      :ok ->
         7
       x ->
         x
@@ -307,43 +257,43 @@
     ```elixir
     # bad
     String.split string, "-", parts: 2
-    
+
     # good
     String.split(string, "-", parts: 2)
     ```
-    
+
     ```elixir
     # bad
     Enum.all? list, fn x -> String.valid?(x) and String.ends_with?(x, "s") end
-    
+
     # good
     Enum.all?(list, fn x -> String.valid?(x) and String.ends_with?(x, "s") end)
     ```
-    
+
     ```elixir
     # bad
-    IO.inspect(some_data_structure, 
-      pretty:    true, 
-      structs:   false,
-      binaries:  :as_strings,
+    IO.inspect(some_data_structure,
+      pretty: true,
+      structs: false,
+      binaries: :as_strings,
       charlists: :as_charlists,
-      base:      :binary)
-      
+      base: :binary)
+
     # good
-    IO.inspect some_data_structure, 
-      pretty:    true, 
-      structs:   false,
-      binaries:  :as_strings,
+    IO.inspect some_data_structure,
+      pretty: true,
+      structs: false,
+      binaries: :as_strings,
       charlists: :as_charlists,
-      base:      :binary
+      base: :binary
     ```
-    
+
     ```elixir
     # bad
     Enumerable.reduce(transactions, {:cont, 0}, fn t, acc ->
       if t.date.year > 2001, do: {:halt, acc}, else: {:cont, acc + t.amount}
     end)
-      
+
     # good
     Enumerable.reduce transactions, {:cont, 0}, fn t, acc ->
       if t.date.year > 2001, do: {:halt, acc}, else: {:cont, acc + t.amount}
@@ -355,28 +305,28 @@
     ```elixir
     # good
     String.capitalize(name)
-    
+
     # also good
     name |> String.capitalize()
     ```
-    
+
     ```elixir
     # bad
     integer |> Integer.to_string(36) |> String.capitalize()
-    
+
     # also bad
-    Integer.to_string(integer, 36) 
-    |> String.capitalize() 
-    
+    Integer.to_string(integer, 36)
+    |> String.capitalize()
+
     # also bad
-    integer 
-    |> Integer.to_string(36) 
+    integer
+    |> Integer.to_string(36)
     |> String.capitalize
-    
+
     # good
-    integer 
-    |> Integer.to_string(36) 
-    |> String.capitalize() 
+    integer
+    |> Integer.to_string(36)
+    |> String.capitalize()
     ```
 
 - Follow multiline calls without a closing parenthesis, square bracket, or curly brace with an empty line, `else`, or `end`.


### PR DESCRIPTION
Why:

* The costs of map/multimap padding alignment outweigh the benefits.

How:

* Remove the alignment prescription.
* Update examples to remove padding.

Also:

* Fix whitespace.