### PR TITLE
Update: Elixir style guide for v1.4

### DIFF
--- a/elixir_style_guide.md
+++ b/elixir_style_guide.md
@@ -58,16 +58,6 @@
 
 - Use `===` unless you actually need `==`. Use `!==` unless you actually need `!=`.
 
-- Omit parentheses from nullary calls.
-
-    ```elixir
-    # bad
-    MapSet.new()
-
-    # good
-    MapSet.new
-    ```
-
 - When a keyword list, list, or map spans multiple lines, place the delimiters on separate lines from the items. Do not omit the comma from the final item.
 
     ```elixir


### PR DESCRIPTION
Why:

* As of v1.4, the Elixir compiler warns when a local, imported, or kernel nullary function is called without parentheses. The mandate to omit parentheses from nullary calls is no longer appropriate.

How:

* Remove mandate to omit parentheses from nullary calls.